### PR TITLE
Feat/a focus guards

### DIFF
--- a/packages/akar/src/a-focus-guards/a-focus-guards.vue
+++ b/packages/akar/src/a-focus-guards/a-focus-guards.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+import { useFocusGuards } from '~~/shared';
+
+useFocusGuards();
+</script>
+
+<template>
+  <slot />
+</template>

--- a/packages/akar/src/a-focus-guards/index.ts
+++ b/packages/akar/src/a-focus-guards/index.ts
@@ -1,0 +1,1 @@
+export { default as AFocusGuards } from './a-focus-guards.vue';

--- a/packages/akar/src/shared/index.ts
+++ b/packages/akar/src/shared/index.ts
@@ -1,2 +1,3 @@
 export { renderSlotFragments } from './render-slot-fragments';
+export { useFocusGuards } from './use-focus-guards';
 export { useForwardExpose } from './use-forward-expose';

--- a/packages/akar/src/shared/use-focus-guards.ts
+++ b/packages/akar/src/shared/use-focus-guards.ts
@@ -1,0 +1,47 @@
+import { isClient } from '@vueuse/shared';
+import { watchEffect } from 'vue';
+
+/** Number of components which have requested interest to have focus guards */
+let count = 0;
+
+/**
+ * Injects a pair of focus guards at the edges of the whole DOM tree
+ * to ensure `focusin` & `focusout` events can be caught consistently.
+ */
+export function useFocusGuards() {
+  watchEffect((cleanupFn) => {
+    if (!isClient) {
+      return;
+    }
+    const edgeGuards = document.querySelectorAll('[data-akar-focus-guard]');
+    document.body.insertAdjacentElement(
+      'afterbegin',
+      edgeGuards[0] ?? createFocusGuard(),
+    );
+    document.body.insertAdjacentElement(
+      'beforeend',
+      edgeGuards[1] ?? createFocusGuard(),
+    );
+    count++;
+
+    cleanupFn(() => {
+      if (count === 1) {
+        document
+          .querySelectorAll('[data-akar-focus-guard]')
+          .forEach((node) => {
+            node.remove();
+          });
+      }
+      count--;
+    });
+  });
+}
+
+function createFocusGuard() {
+  const element = document.createElement('span');
+  element.setAttribute('data-akar-focus-guard', '');
+  element.tabIndex = 0;
+  element.style.cssText
+    = 'outline: none; opacity: 0; position: fixed; pointer-events: none';
+  return element;
+}

--- a/packages/akar/src/shared/use-focus-guards.ts
+++ b/packages/akar/src/shared/use-focus-guards.ts
@@ -1,4 +1,4 @@
-import { isClient } from '@vueuse/shared';
+import { isBrowser } from '@vinicunca/perkakas';
 import { watchEffect } from 'vue';
 
 /** Number of components which have requested interest to have focus guards */
@@ -10,7 +10,7 @@ let count = 0;
  */
 export function useFocusGuards() {
   watchEffect((cleanupFn) => {
-    if (!isClient) {
+    if (!isBrowser) {
       return;
     }
     const edgeGuards = document.querySelectorAll('[data-akar-focus-guard]');


### PR DESCRIPTION
Adding akar focus guards as a component and an utility function. It Injects a pair of focus guards at the edges of the whole DOM tree to ensure `focusin` & `focusout` events can be caught consistently.


This PR is dependent on the [Akar Focus Scope PR](https://github.com/vinicunca/akar/pull/6/files) 